### PR TITLE
Handle `AttributeError`

### DIFF
--- a/custom_components/speedport/device_tracker.py
+++ b/custom_components/speedport/device_tracker.py
@@ -123,8 +123,12 @@ class SpeedportTracker(CoordinatorEntity, ScannerEntity):
 
     @property
     def name(self) -> str:
-        """Return device name."""
-        return self._device.name
+        try:
+            """Return device name."""
+            return self._device.name
+        except AttributeError:
+            """The device is disconnected or unavailable in the router."""
+            return ""
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/speedport/device_tracker.py
+++ b/custom_components/speedport/device_tracker.py
@@ -61,23 +61,39 @@ class SpeedportTracker(CoordinatorEntity, ScannerEntity):
 
     @property
     def hostname(self) -> str | None:
-        """Return the hostname of device."""
-        return self._device.name
+        try:
+            """Return the hostname of device."""
+            return self._device.name
+        except AttributeError:
+            """The device is disconnected or unavailable in the router."""
+            return None
 
     @property
     def ip_address(self) -> str | None:
-        """Return the primary ip address of the device."""
-        return self._device.ipv4
+        try:
+            """Return the primary ip address of the device."""
+            return self._device.ipv4
+        except AttributeError:
+            """The device is disconnected or unavailable in the router."""
+            return None
 
     @property
     def is_connected(self) -> bool:
-        """Return device status."""
-        return self._device.connected
+        try:
+            """Return device status."""
+            return self._device.connected
+        except AttributeError:
+            """The device is disconnected or unavailable in the router."""
+            return False
 
     @property
     def mac_address(self) -> str:
-        """Return mac_address."""
-        return self._device.mac
+        try:
+            """Return mac_address."""
+            return self._device.mac
+        except AttributeError:
+            """The device is disconnected or unavailable in the router."""
+            return ""
 
     @property
     def icon(self) -> str:


### PR DESCRIPTION
This PR fixes the issue #16.

When the device is disconnected from Speedport, the router removes the device from the list and makes the `device` to `None` state. Whenever the device is requested for an attribute, because of `None`, it throws the `AttributeError`.

I tested these changes on my Speedport.

When the device is connected to Wi-Fi.

![FireShot Capture 175 - Developer tools – Home Assistant - assistant home matriphe net](https://github.com/Andre0512/speedport/assets/277262/4458eb96-7f73-4816-80a5-4bdda8bb5da4)

Then when I disconnected my device, it shows below.

![FireShot Capture 176 - Developer tools – Home Assistant - assistant home matriphe net](https://github.com/Andre0512/speedport/assets/277262/d0f39326-8d58-48b8-97a3-063b0d2cea08)

I'm not good at Python, and I know that this solution is quick and dirty, but it works!
