### PR TITLE
'speedport' calls async_forward_entry_setup / This will stop working in Home Assistant 2025.6 #30 - Update __init__.py

### DIFF
--- a/custom_components/speedport/__init__.py
+++ b/custom_components/speedport/__init__.py
@@ -37,10 +37,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    
     return True
 
 


### PR DESCRIPTION
Detected that custom integration 'speedport' calls async_forward_entry_setup for integration, speedport with title: Speedport and entry_id: 01JNVBAZRVQVQFF4YPWEF3KDY9, which is deprecated, await async_forward_entry_setups instead