### PR TITLE
Fixed deprecated OptionsFlowHandler

### DIFF
--- a/custom_components/speedport/config_flow.py
+++ b/custom_components/speedport/config_flow.py
@@ -83,7 +83,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> config_entries.OptionsFlow:
         """Create the options flow."""
-        return OptionsFlowHandler(config_entry)
+        return OptionsFlowHandler()
 
 
 class CannotConnect(HomeAssistantError):
@@ -95,9 +95,6 @@ class InvalidAuth(HomeAssistantError):
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
This PR fixes [https://developers.home-assistant.io/blog/2024/11/12/options-flow/](https://developers.home-assistant.io/blog/2024/11/12/options-flow/). 
